### PR TITLE
Fixed a typo saying $D  to 4D

### DIFF
--- a/module_intros/Order-NematicOrderParameter.ipynb
+++ b/module_intros/Order-NematicOrderParameter.ipynb
@@ -34,7 +34,7 @@
    "source": [
     "In order to work with orientations in freud, we need to do some math with quaternions.\n",
     "If you are unfamiliar with quaternions, you can read more about [their definition](https://en.wikipedia.org/wiki/Quaternion) and how they can be used to [represent rotations](https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation).\n",
-    "For the purpose of this tutorial, just consider them as 4D vectors, and know that the set of normalized (*i.e.* unit norm) $D vectors can be used to represent rotations in 3D.\n",
+    "For the purpose of this tutorial, just consider them as 4D vectors, and know that the set of normalized (*i.e.* unit norm) 4D vectors can be used to represent rotations in 3D.\n",
     "In fact, there is a 1-1 mapping between normalize quaternions and 3x3 rotation matrices.\n",
     "Quaternions are more computationally convenient, however, because they only require storing 4 numbers rather than 9, and they can be much more easily chained together.\n",
     "For our purposes, you can largely ignore the contents of the next cell, other than to note that this is how we perform rotations of vectors using quaternions instead of matrices."


### PR DESCRIPTION
There was a typo in the example doc for NematicOrderParameter saying $D instead of 4D.