### PR TITLE
Update fresnel/plato-draw requirements.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ channels:
   - conda-forge
 dependencies:
   - bokeh
-  - fresnel
+  - fresnel>=0.12
   - freud
   - gsd
   - hoomd=2.*
@@ -23,5 +23,5 @@ dependencies:
   - scipy
   - tqdm
   - pip:
-    - plato-draw
+    - plato-draw>=1.12
     - umap-learn


### PR DESCRIPTION
I fixed fresnel 0.12/0.13 compatibility in plato 1.12. This PR should fix the failing CI for freud-examples.