### PR TITLE
Add CODEOWNERS, PR template, LICENSE, and Contributor Agreement.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Request a freud developer on each pull request.
+* @glotzerlab/freud-developers
+# Request maintainers for changes to requirements or CI
+requirements/* @glotzerlab/freud-maintainers
+requirements.txt @glotzerlab/freud-maintainers
+environment.yml @glotzerlab/freud-maintainers
+.github @glotzerlab/freud-maintainers
+.pre-commit-config.yaml @glotzerlab/freud-maintainers

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## Description
+<!-- Describe your changes in detail. -->
+
+<!-- Replace ??? with the issue number that this pull request resolves, if applicable. -->
+Resolves: #???
+
+## Checklist:
+<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
+     these, don't hesitate to ask. We're here to help! -->
+- [ ] I agree with the terms of the [**freud Contributor Agreement**](https://github.com/glotzerlab/freud-examples/blob/master/ContributorAgreement.md).
+- [ ] My code follows the code style of this project.
+- [ ] I have updated the [index notebook](https://github.com/glotzerlab/freud-examples/blob/master/index.ipynb) if needed.
+- [ ] My name is on the [contributors list](https://github.com/glotzerlab/freud-examples/blob/master/contributors.txt).

--- a/ContributorAgreement.md
+++ b/ContributorAgreement.md
@@ -1,0 +1,28 @@
+# freud Contributor Agreement
+
+These terms apply to your contribution to the freud Open Source Project ("Project") owned or managed by the Regents of the University of Michigan ("Michigan"), and set out the intellectual property rights you grant to Michigan in the contributed materials. If this contribution is on behalf of a company, the term "you" will also mean the company you identify below. If you agree to be bound by these terms, fill in the information requested below and provide your signature.
+
+1. The term "contribution" means any source code, object code, patch, tool, sample, graphic, specification, manual, documentation, or any other material posted or submitted by you to a project.
+2. With respect to any worldwide copyrights, or copyright applications and registrations, in your contribution:
+    * you hereby assign to Michigan joint ownership, and to the extent that such assignment is or becomes invalid, ineffective or unenforceable, you hereby grant to Michigan a perpetual, irrevocable, non-exclusive, worldwide, no-charge, royalty-free, unrestricted license to exercise all rights under those copyrights. This includes, at Michigan's option, the right to sublicense these same rights to third parties through multiple levels of sublicensees or other licensing arrangements;
+    * you agree that both Michigan and you can do all things in relation to your contribution as if each of us were the sole owners, and if one of us makes a derivative work of your contribution, the one who makes the derivative work (or has it made) will be the sole owner of that derivative work;
+    * you agree that you will not assert any moral rights in your contribution against us, our licensees or transferees;
+    * you agree that we may register a copyright in your contribution and exercise all ownership rights associated with it; and
+    * you agree that neither of us has any duty to consult with, obtain the consent of, pay or render an accounting to the other for any use or distribution of your contribution.
+3. With respect to any patents you own, or that you can license without payment to any third party, you hereby grant to Michigan a perpetual, irrevocable, non-exclusive, worldwide, no-charge, royalty-free license to:
+    * make, have made, use, sell, offer to sell, import, and otherwise transfer your contribution in whole or in part, alone or in combination with or included in any product, work or materials arising out of the project to which your contribution was submitted; and
+    * at Michigan's option, to sublicense these same rights to third parties through multiple levels of sublicensees or other licensing arrangements.
+4. Except as set out above, you keep all right, title, and interest in your contribution. The rights that you grant to Michigan under these terms are effective on the date you first submitted a contribution to Michigan, even if your submission took place before the date you sign these terms. Any contribution Michigan makes available under any license will also be made available under a suitable Free Software Foundation or Open Source Initiative approved license.
+5. With respect to your contribution, you represent that:
+    * it is an original work and that you can legally grant the rights set out in these terms;
+    * it does not to the best of your knowledge violate any third party's copyrights, trademarks, patents, or other intellectual property rights; and
+you are authorized to sign this contract on behalf of your company (if identified below).
+6. The terms will be governed by the laws of the State of Michigan and applicable U.S. Federal Law. Any choice of law rules will not apply.
+
+**By making contribution, you electronically sign and agree to the terms of the freud Contributor Agreement.**
+
+![by-sa.png](https://licensebuttons.net/l/by-sa/3.0/88x31.png)
+
+Based on the Sun Contributor Agreement - version 1.5.
+This document is licensed under a Creative Commons Attribution-Share Alike 3.0 Unported License
+https://creativecommons.org/licenses/by-sa/3.0/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License for freud
+
+Copyright (c) 2010-2021 The Regents of the University of Michigan
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software without
+   specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
This repo doesn't have any `CODEOWNERS` set, so we don't automatically get reviewers assigned. This adds some of the core files needed for repository configuration / contributor agreements.