### PR TITLE
Build Freud's next branch in CI tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ on:
   # request source branch is in the same repository.
   push:
     branches:
-      - "master"
+      - "next"
 
   # Trigger on request.
   workflow_dispatch:
@@ -54,6 +54,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         path: freud
+        ref: next
         repository: glotzerlab/freud
         submodules: true
     - name: Install freud

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ on:
   # request source branch is in the same repository.
   push:
     branches:
+      - "master"
       - "next"
 
   # Trigger on request.


### PR DESCRIPTION
## Description

Freud will be making a version 3 release, which will require updates to the examples. To update those examples, I recently created the `next` branch in this repo to mirror freud's `next` branch. To unit test the updated examples, we need CI to build freud's next branch instead of freud's master branch.

This PR implements the changes necessary for that to occur.

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [ ] I agree with the terms of the [**freud Contributor Agreement**](https://github.com/glotzerlab/freud-examples/blob/master/ContributorAgreement.md).
- [ ] My code follows the code style of this project.
- [ ] I have updated the [index notebook](https://github.com/glotzerlab/freud-examples/blob/master/index.ipynb) if needed.
- [ ] My name is on the [contributors list](https://github.com/glotzerlab/freud-examples/blob/master/contributors.txt).
