### PR TITLE
CI use python 3.10 instead of 3.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.11"]
+        python-version: ["3.9", "3.10"]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.9"]
+        python-version: ["3.9", "3.11"]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
## Description

Python 3.7 is now a very old version, and we need to be testing on newer python versions.

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [ ] I agree with the terms of the [**freud Contributor Agreement**](https://github.com/glotzerlab/freud-examples/blob/master/ContributorAgreement.md).
- [ ] My code follows the code style of this project.
- [ ] I have updated the [index notebook](https://github.com/glotzerlab/freud-examples/blob/master/index.ipynb) if needed.
- [ ] My name is on the [contributors list](https://github.com/glotzerlab/freud-examples/blob/master/contributors.txt).
